### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ cp -r skills/prd ~/.config/amp/skills/
 cp -r skills/ralph ~/.config/amp/skills/
 ```
 
-### Option 3: Install with sk
+### Option 3: Install with `sk`
 
-Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude Code, Amp, Codex, OpenCode, etc.).
+Install Ralph via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Codex, Amp, OpenCode, Factory, Claude Code etc...).
 
 ```bash
+# Add --global flag if you'd like to install in user-scope (defaults to project-scope)
 sk pkg add gh snarktank/ralph --path skills
 sk sync
 ```


### PR DESCRIPTION
`sk` is a universal package manager (works across all coding agents), handles updates, etc.. (npm/cargo for agents).

would you be open to adding this?
