### PR TITLE
Add PRD validation script to fail fast on common mistakes

### DIFF
--- a/ralph.sh
+++ b/ralph.sh
@@ -11,40 +11,40 @@ PROGRESS_FILE="$SCRIPT_DIR/progress.txt"
 ARCHIVE_DIR="$SCRIPT_DIR/archive"
 LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
 
-
+# ------------------------------------------------------------
 # Fail fast on malformed PRDs before starting the agent loop
-if [ -f "$SCRIPT_DIR/validator_prd.sh" ]; then
-  "$SCRIPT_DIR/validator_prd.sh" "$PRD_FILE"
+# ------------------------------------------------------------
+if [ -f "$SCRIPT_DIR/scripts/validate_prd.sh" ]; then
+  "$SCRIPT_DIR/scripts/validate_prd.sh" "$PRD_FILE"
 fi
 
-
-
+# ------------------------------------------------------------
 # Archive previous run if branch changed
+# ------------------------------------------------------------
 if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
   CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
   LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
-  
+
   if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
-    # Archive the previous run
     DATE=$(date +%Y-%m-%d)
-    # Strip "ralph/" prefix from branch name for folder
     FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
     ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
-    
+
     echo "Archiving previous run: $LAST_BRANCH"
     mkdir -p "$ARCHIVE_FOLDER"
     [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
     [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
     echo "   Archived to: $ARCHIVE_FOLDER"
-    
-    # Reset progress file for new run
+
     echo "# Ralph Progress Log" > "$PROGRESS_FILE"
     echo "Started: $(date)" >> "$PROGRESS_FILE"
     echo "---" >> "$PROGRESS_FILE"
   fi
 fi
 
+# ------------------------------------------------------------
 # Track current branch
+# ------------------------------------------------------------
 if [ -f "$PRD_FILE" ]; then
   CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
   if [ -n "$CURRENT_BRANCH" ]; then
@@ -52,7 +52,9 @@ if [ -f "$PRD_FILE" ]; then
   fi
 fi
 
-# Initialize progress file if it doesn't exist
+# ------------------------------------------------------------
+# Initialize progress file if needed
+# ------------------------------------------------------------
 if [ ! -f "$PROGRESS_FILE" ]; then
   echo "# Ralph Progress Log" > "$PROGRESS_FILE"
   echo "Started: $(date)" >> "$PROGRESS_FILE"
@@ -61,23 +63,24 @@ fi
 
 echo "Starting Ralph - Max iterations: $MAX_ITERATIONS"
 
-for i in $(seq 1 $MAX_ITERATIONS); do
+# ------------------------------------------------------------
+# Main agent loop
+# ------------------------------------------------------------
+for i in $(seq 1 "$MAX_ITERATIONS"); do
   echo ""
   echo "═══════════════════════════════════════════════════════"
   echo "  Ralph Iteration $i of $MAX_ITERATIONS"
   echo "═══════════════════════════════════════════════════════"
-  
-  # Run amp with the ralph prompt
+
   OUTPUT=$(cat "$SCRIPT_DIR/prompt.md" | amp --dangerously-allow-all 2>&1 | tee /dev/stderr) || true
-  
-  # Check for completion signal
+
   if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
     echo ""
     echo "Ralph completed all tasks!"
     echo "Completed at iteration $i of $MAX_ITERATIONS"
     exit 0
   fi
-  
+
   echo "Iteration $i complete. Continuing..."
   sleep 2
 done

--- a/ralph.sh
+++ b/ralph.sh
@@ -11,6 +11,14 @@ PROGRESS_FILE="$SCRIPT_DIR/progress.txt"
 ARCHIVE_DIR="$SCRIPT_DIR/archive"
 LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
 
+
+# Fail fast on malformed PRDs before starting the agent loop
+if [ -f "$SCRIPT_DIR/validator_prd.sh" ]; then
+  "$SCRIPT_DIR/validator_prd.sh" "$PRD_FILE"
+fi
+
+
+
 # Archive previous run if branch changed
 if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
   CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")

--- a/scripts/validate_prd.sh
+++ b/scripts/validate_prd.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e
+
+FILE=${1:-prd.json}
+
+if [ ! -f "$FILE" ]; then
+  echo "✗ PRD file not found: $FILE"
+  exit 1
+fi
+
+REQUIRED_FIELDS=("id" "description" "status" "priority")
+VALID_STATUS=("todo" "in_progress" "done")
+
+ERROR=0
+
+echo "Validating PRD: $FILE"
+echo "-------------------------"
+
+IDS=$(jq -r '.tasks[].id' "$FILE")
+
+# Duplicate IDs
+DUP_IDS=$(echo "$IDS" | sort | uniq -d)
+if [ -n "$DUP_IDS" ]; then
+  echo "✗ Duplicate task IDs:"
+  echo "$DUP_IDS"
+  ERROR=1
+fi
+
+# Validate each task
+COUNT=$(jq '.tasks | length' "$FILE")
+
+for ((i=0; i<COUNT; i++)); do
+  for FIELD in "${REQUIRED_FIELDS[@]}"; do
+    VALUE=$(jq -r ".tasks[$i].$FIELD // empty" "$FILE")
+    if [ -z "$VALUE" ]; then
+      echo "✗ Missing field '$FIELD' in task index $i"
+      ERROR=1
+    fi
+  done
+
+  STATUS=$(jq -r ".tasks[$i].status" "$FILE")
+  if [[ ! " ${VALID_STATUS[*]} " =~ " $STATUS " ]]; then
+    echo "✗ Invalid status '$STATUS' in task index $i"
+    ERROR=1
+  fi
+done
+
+if [ "$ERROR" -eq 0 ]; then
+  echo "✓ PRD is valid"
+else
+  echo "✗ PRD validation failed"
+  exit 1
+fi

--- a/scripts/validate_prd.sh
+++ b/scripts/validate_prd.sh
@@ -8,41 +8,39 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 
-REQUIRED_FIELDS=("id" "description" "status" "priority")
-VALID_STATUS=("todo" "in_progress" "done")
+if ! command -v jq >/dev/null 2>&1; then
+  echo "✗ jq is required but not installed"
+  exit 1
+fi
 
+REQUIRED_FIELDS=("id" "title" "priority")
 ERROR=0
 
 echo "Validating PRD: $FILE"
 echo "-------------------------"
 
-IDS=$(jq -r '.tasks[].id' "$FILE")
+# Collect all user story IDs
+IDS=$(jq -r '.userStories[].id' "$FILE")
 
-# Duplicate IDs
+# Check for duplicate IDs
 DUP_IDS=$(echo "$IDS" | sort | uniq -d)
 if [ -n "$DUP_IDS" ]; then
-  echo "✗ Duplicate task IDs:"
+  echo "✗ Duplicate userStory IDs:"
   echo "$DUP_IDS"
   ERROR=1
 fi
 
-# Validate each task
-COUNT=$(jq '.tasks | length' "$FILE")
+# Validate each user story
+COUNT=$(jq '.userStories | length' "$FILE")
 
 for ((i=0; i<COUNT; i++)); do
   for FIELD in "${REQUIRED_FIELDS[@]}"; do
-    VALUE=$(jq -r ".tasks[$i].$FIELD // empty" "$FILE")
+    VALUE=$(jq -r ".userStories[$i].$FIELD // empty" "$FILE")
     if [ -z "$VALUE" ]; then
-      echo "✗ Missing field '$FIELD' in task index $i"
+      echo "✗ Missing field '$FIELD' in userStory index $i"
       ERROR=1
     fi
   done
-
-  STATUS=$(jq -r ".tasks[$i].status" "$FILE")
-  if [[ ! " ${VALID_STATUS[*]} " =~ " $STATUS " ]]; then
-    echo "✗ Invalid status '$STATUS' in task index $i"
-    ERROR=1
-  fi
 done
 
 if [ "$ERROR" -eq 0 ]; then
@@ -51,3 +49,8 @@ else
   echo "✗ PRD validation failed"
   exit 1
 fi
+
+
+# // this is the main file that i have added validate_prd.sh file in the main root folder i have made a file name 
+# prd.json.example also in the main root folder
+# // now i will run this script to validate the prd.json file

--- a/scripts/validate_prd.sh
+++ b/scripts/validate_prd.sh
@@ -45,10 +45,11 @@ COUNT=$(jq '.userStories | length' "$FILE")
 for ((i=0; i<COUNT; i++)); do
   for FIELD in "${REQUIRED_FIELDS[@]}"; do
     EXISTS=$(jq ".userStories[$i] | has(\"$FIELD\")" "$FILE")
-    if [ "$EXISTS" != "true" ]; then
-      echo "✗ Missing field '$FIELD' in userStory index $i"
-      ERROR=1
+    # Fail fast on malformed PRDs before starting the agent loop
+    if [ -f "$SCRIPT_DIR/scripts/validate_prd.sh" ]; then
+      "$SCRIPT_DIR/scripts/validate_prd.sh" "$PRD_FILE"
     fi
+
   done
 done
 


### PR DESCRIPTION
Problem:
Several users (including me) hit avoidable failures when running Ralph
due to small PRD mistakes (duplicate IDs, missing fields, invalid status).

Change:
This PR adds a lightweight PRD validation script that fails fast before
the agent loop starts, saving time and API usage. I also clarified the
PRD format in the README so expectations are explicit.

Why small + separate:
I intentionally kept this out of the main loop to avoid changing Ralph’s
runtime behavior and keep it optional.
