### PR TITLE
docs: clarify setup instructions and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ryan Carson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Based on [Geoffrey Huntley's Ralph pattern](https://ghuntley.com/ralph/).
 
 ## Setup
 
-### Option 1: Copy to your project
+Choose **one** of the following setup approaches:
 
-Copy the ralph files into your project:
+### Approach A: Project-local setup (recommended for teams)
+
+Keep everything in your project repository so teammates get Ralph automatically:
 
 ```bash
 # From your project root
@@ -33,23 +35,30 @@ cp /path/to/ralph/prompt.md scripts/ralph/prompt.md    # For Amp
 cp /path/to/ralph/CLAUDE.md scripts/ralph/CLAUDE.md    # For Claude Code
 
 chmod +x scripts/ralph/ralph.sh
+
+# Also copy the skills to your project
+cp -r /path/to/ralph/skills .claude/skills/    # For Claude Code
+# OR
+cp -r /path/to/ralph/skills .amp/skills/       # For Amp
 ```
 
-### Option 2: Install skills globally
+### Approach B: Global setup (for personal use across projects)
 
-Copy the skills to your Amp or Claude config for use across all projects:
+Install Ralph globally so it's available in any project:
 
-For AMP
+**For Amp:**
 ```bash
 cp -r skills/prd ~/.config/amp/skills/
 cp -r skills/ralph ~/.config/amp/skills/
 ```
 
-For Claude Code
+**For Claude Code:**
 ```bash
 cp -r skills/prd ~/.claude/skills/
 cp -r skills/ralph ~/.claude/skills/
 ```
+
+Then copy `ralph.sh` and the prompt template to each project as needed.
 
 ### Configure Amp auto-handoff (recommended)
 


### PR DESCRIPTION
## Summary

- **Fixes #19**: Reworded the Setup section to clarify that "Approach A" (project-local) and "Approach B" (global) are distinct setup strategies, not sequential steps. The previous "Option 1/Option 2" wording implied mutual exclusivity which confused new users.

- **Fixes #22**: Added MIT LICENSE file to enable enterprise adoption and clarify usage rights.

## Changes

### README.md
- Renamed "Option 1/Option 2" to "Approach A/Approach B" 
- Added clear descriptions: "recommended for teams" vs "for personal use"
- Included skills copy step in Approach A for completeness

### LICENSE
- Added standard MIT license with Ryan Carson as copyright holder

## Test plan

- [x] README renders correctly on GitHub
- [x] License file is valid MIT format