### PR TITLE
feat: Add multi-PRD support for sequential processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 prd.json
 progress.txt
 .last-branch
+.completed-prds
 
 # Archive is optional to commit
 # archive/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Ralph is an autonomous AI agent loop that runs AI coding tools ([Amp](https://ampcode.com) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code)) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context. Memory persists via git history, `progress.txt`, and `prd.json`.
 
+**Now with Multi-PRD support!** Queue multiple PRDs in a `prds/` directory and Ralph will process them automatically from highest to lowest priority.
+
 Based on [Geoffrey Huntley's Ralph pattern](https://ghuntley.com/ralph/).
 
 [Read my in-depth article on how I use Ralph](https://x.com/ryancarson/status/2008548371712135632)
@@ -107,6 +109,69 @@ Ralph will:
 7. Append learnings to `progress.txt`
 8. Repeat until all stories pass or max iterations reached
 
+## Multi-PRD Mode
+
+Queue multiple PRDs and Ralph will process them automatically from highest to lowest priority.
+
+### Setup
+
+1. Create a `prds/` directory in your ralph folder:
+```bash
+mkdir -p scripts/ralph/prds
+```
+
+2. Add PRD files with a `priority` field (lower number = higher priority):
+```json
+{
+  "project": "MyApp",
+  "branchName": "ralph/feature-one",
+  "description": "First feature to implement",
+  "priority": 1,
+  "userStories": [...]
+}
+```
+
+3. Run Ralph - it auto-detects the `prds/` directory:
+```bash
+./scripts/ralph/ralph.sh --tool claude 15
+```
+
+### How It Works
+
+- Ralph automatically detects the `prds/` directory and enables multi-PRD mode
+- PRDs are processed in priority order (1, 2, 3, etc.)
+- After completing all stories in a PRD, Ralph:
+  - Archives the completed PRD
+  - Resets the progress log
+  - Activates the next PRD in the queue
+- Continues until all PRDs are complete
+
+### Example Output
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║           RALPH - Multi-PRD Mode                              ║
+╠═══════════════════════════════════════════════════════════════╣
+║  Tool: claude
+║  Max iterations per PRD: 10
+║  PRDs directory: /path/to/prds
+╚═══════════════════════════════════════════════════════════════╝
+
+PRD Queue (by priority):
+─────────────────────────────────────────────────────────────────
+  Priority 1: DatabaseSetup                [0/3] 01-database.json
+  Priority 2: UserAuth                     [0/4] 02-auth.json
+  Priority 3: TaskManagement               [0/5] 03-tasks.json
+─────────────────────────────────────────────────────────────────
+```
+
+### Tracking Files
+
+| File | Purpose |
+|------|---------|
+| `prds/*.json` | PRD queue - each file is a separate PRD with priority |
+| `.completed-prds` | Tracks which PRDs have been completed |
+
 ## Key Files
 
 | File | Purpose |
@@ -116,6 +181,9 @@ Ralph will:
 | `CLAUDE.md` | Prompt template for Claude Code |
 | `prd.json` | User stories with `passes` status (the task list) |
 | `prd.json.example` | Example PRD format for reference |
+| `prds/` | Directory for multi-PRD mode - place PRD files here with priority field |
+| `prds/*.json.example` | Example PRD files showing multi-PRD setup |
+| `.completed-prds` | Tracks completed PRDs in multi-PRD mode |
 | `progress.txt` | Append-only learnings for future iterations |
 | `skills/prd/` | Skill for generating PRDs |
 | `skills/ralph/` | Skill for converting PRDs to JSON |

--- a/prd.json.example
+++ b/prd.json.example
@@ -2,6 +2,7 @@
   "project": "MyApp",
   "branchName": "ralph/task-priority",
   "description": "Task Priority System - Add priority levels to tasks",
+  "priority": 1,
   "userStories": [
     {
       "id": "US-001",

--- a/prds/01-database-setup.json.example
+++ b/prds/01-database-setup.json.example
@@ -1,0 +1,36 @@
+{
+  "project": "MyApp",
+  "branchName": "ralph/database-setup",
+  "description": "Database Setup - Initialize core database schema",
+  "priority": 1,
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Create users table",
+      "description": "As a developer, I need a users table to store user accounts.",
+      "acceptanceCriteria": [
+        "Create users table with id, email, name, created_at columns",
+        "Add unique constraint on email",
+        "Migration runs successfully",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Create tasks table",
+      "description": "As a developer, I need a tasks table to store user tasks.",
+      "acceptanceCriteria": [
+        "Create tasks table with id, user_id, title, completed, created_at columns",
+        "Add foreign key constraint to users table",
+        "Migration runs successfully",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prds/02-user-auth.json.example
+++ b/prds/02-user-auth.json.example
@@ -1,0 +1,38 @@
+{
+  "project": "MyApp",
+  "branchName": "ralph/user-auth",
+  "description": "User Authentication - Add login and registration",
+  "priority": 2,
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add registration form",
+      "description": "As a user, I want to create an account.",
+      "acceptanceCriteria": [
+        "Registration form with email and password fields",
+        "Form validation for email format and password strength",
+        "Success message on registration",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add login form",
+      "description": "As a user, I want to log into my account.",
+      "acceptanceCriteria": [
+        "Login form with email and password fields",
+        "Error message for invalid credentials",
+        "Redirect to dashboard on success",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prds/03-task-management.json.example
+++ b/prds/03-task-management.json.example
@@ -1,0 +1,38 @@
+{
+  "project": "MyApp",
+  "branchName": "ralph/task-management",
+  "description": "Task Management - CRUD operations for tasks",
+  "priority": 3,
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Display task list",
+      "description": "As a user, I want to see my tasks.",
+      "acceptanceCriteria": [
+        "Task list shows all user tasks",
+        "Each task shows title and completion status",
+        "Empty state when no tasks exist",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add new task",
+      "description": "As a user, I want to create new tasks.",
+      "acceptanceCriteria": [
+        "Add task form with title input",
+        "New task appears in list immediately",
+        "Form clears after submission",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/ralph.sh
+++ b/ralph.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-# Ralph Wiggum - Long-running AI agent loop
-# Usage: ./ralph.sh [--tool amp|claude] [max_iterations]
+# Ralph Wiggum - Long-running AI agent loop with multi-PRD support
+# Usage: ./ralph.sh [--tool amp|claude] [--multi] [max_iterations]
+#
+# Multi-PRD mode: Place PRD files in prds/ directory with a "priority" field.
+# Ralph processes PRDs from highest priority (lowest number) to lowest.
 
 set -e
 
 # Parse arguments
 TOOL="amp"  # Default to amp for backwards compatibility
 MAX_ITERATIONS=10
+MULTI_PRD_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -16,6 +20,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tool=*)
       TOOL="${1#*=}"
+      shift
+      ;;
+    --multi)
+      MULTI_PRD_MODE=true
       shift
       ;;
     *)
@@ -33,43 +41,186 @@ if [[ "$TOOL" != "amp" && "$TOOL" != "claude" ]]; then
   echo "Error: Invalid tool '$TOOL'. Must be 'amp' or 'claude'."
   exit 1
 fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRD_FILE="$SCRIPT_DIR/prd.json"
+PRDS_DIR="$SCRIPT_DIR/prds"
 PROGRESS_FILE="$SCRIPT_DIR/progress.txt"
 ARCHIVE_DIR="$SCRIPT_DIR/archive"
 LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
+COMPLETED_PRDS_FILE="$SCRIPT_DIR/.completed-prds"
 
-# Archive previous run if branch changed
-if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
-  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
-  LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
-  
-  if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
-    # Archive the previous run
-    DATE=$(date +%Y-%m-%d)
-    # Strip "ralph/" prefix from branch name for folder
-    FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
-    ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
-    
-    echo "Archiving previous run: $LAST_BRANCH"
-    mkdir -p "$ARCHIVE_FOLDER"
-    [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
-    [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
-    echo "   Archived to: $ARCHIVE_FOLDER"
-    
-    # Reset progress file for new run
-    echo "# Ralph Progress Log" > "$PROGRESS_FILE"
-    echo "Started: $(date)" >> "$PROGRESS_FILE"
-    echo "---" >> "$PROGRESS_FILE"
-  fi
-fi
+# =============================================================================
+# Multi-PRD Helper Functions
+# =============================================================================
 
-# Track current branch
-if [ -f "$PRD_FILE" ]; then
-  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
-  if [ -n "$CURRENT_BRANCH" ]; then
-    echo "$CURRENT_BRANCH" > "$LAST_BRANCH_FILE"
+# Check if a PRD is complete (all user stories have passes: true)
+is_prd_complete() {
+  local prd_file="$1"
+  if [ ! -f "$prd_file" ]; then
+    return 1
   fi
+
+  local incomplete_count
+  incomplete_count=$(jq '[.userStories[] | select(.passes == false)] | length' "$prd_file" 2>/dev/null || echo "-1")
+
+  if [ "$incomplete_count" = "0" ]; then
+    return 0  # Complete
+  else
+    return 1  # Not complete
+  fi
+}
+
+# Get the next PRD to work on (highest priority = lowest number, not yet complete)
+get_next_prd() {
+  if [ ! -d "$PRDS_DIR" ]; then
+    echo ""
+    return
+  fi
+
+  # Initialize completed PRDs tracking file
+  touch "$COMPLETED_PRDS_FILE"
+
+  # Find all PRD files, sort by priority (lowest first), return first incomplete one
+  local next_prd=""
+  local lowest_priority=999999
+
+  for prd in "$PRDS_DIR"/*.json; do
+    [ -f "$prd" ] || continue
+
+    local prd_name
+    prd_name=$(basename "$prd")
+
+    # Skip if already marked as completed
+    if grep -q "^${prd_name}$" "$COMPLETED_PRDS_FILE" 2>/dev/null; then
+      continue
+    fi
+
+    # Check if PRD is complete
+    if is_prd_complete "$prd"; then
+      echo "$prd_name" >> "$COMPLETED_PRDS_FILE"
+      continue
+    fi
+
+    # Get priority (default to 999 if not specified)
+    local priority
+    priority=$(jq -r '.priority // 999' "$prd" 2>/dev/null || echo "999")
+
+    if [ "$priority" -lt "$lowest_priority" ]; then
+      lowest_priority=$priority
+      next_prd="$prd"
+    fi
+  done
+
+  echo "$next_prd"
+}
+
+# Count remaining incomplete PRDs
+count_remaining_prds() {
+  if [ ! -d "$PRDS_DIR" ]; then
+    echo "0"
+    return
+  fi
+
+  local count=0
+  for prd in "$PRDS_DIR"/*.json; do
+    [ -f "$prd" ] || continue
+
+    local prd_name
+    prd_name=$(basename "$prd")
+
+    # Skip if already marked as completed
+    if grep -q "^${prd_name}$" "$COMPLETED_PRDS_FILE" 2>/dev/null; then
+      continue
+    fi
+
+    if ! is_prd_complete "$prd"; then
+      ((count++))
+    fi
+  done
+
+  echo "$count"
+}
+
+# Activate a PRD (copy to prd.json for the agent to work on)
+activate_prd() {
+  local prd_file="$1"
+  if [ -z "$prd_file" ] || [ ! -f "$prd_file" ]; then
+    return 1
+  fi
+
+  local prd_name
+  prd_name=$(basename "$prd_file")
+  local project_name
+  project_name=$(jq -r '.project // "Unknown"' "$prd_file")
+  local priority
+  priority=$(jq -r '.priority // "N/A"' "$prd_file")
+
+  echo ""
+  echo "==============================================================="
+  echo "  Activating PRD: $prd_name"
+  echo "  Project: $project_name | Priority: $priority"
+  echo "==============================================================="
+
+  cp "$prd_file" "$PRD_FILE"
+  return 0
+}
+
+# Sync changes back to source PRD file
+sync_prd_changes() {
+  local source_prd="$1"
+  if [ -n "$source_prd" ] && [ -f "$source_prd" ] && [ -f "$PRD_FILE" ]; then
+    cp "$PRD_FILE" "$source_prd"
+  fi
+}
+
+# =============================================================================
+# Archive Functions
+# =============================================================================
+
+archive_previous_run() {
+  if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
+    CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+    LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
+
+    if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
+      # Archive the previous run
+      DATE=$(date +%Y-%m-%d)
+      # Strip "ralph/" prefix from branch name for folder
+      FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
+      ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
+
+      echo "Archiving previous run: $LAST_BRANCH"
+      mkdir -p "$ARCHIVE_FOLDER"
+      [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
+      [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
+      echo "   Archived to: $ARCHIVE_FOLDER"
+
+      # Reset progress file for new run
+      echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+      echo "Started: $(date)" >> "$PROGRESS_FILE"
+      echo "---" >> "$PROGRESS_FILE"
+    fi
+  fi
+}
+
+track_current_branch() {
+  if [ -f "$PRD_FILE" ]; then
+    CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+    if [ -n "$CURRENT_BRANCH" ]; then
+      echo "$CURRENT_BRANCH" > "$LAST_BRANCH_FILE"
+    fi
+  fi
+}
+
+# =============================================================================
+# Main Execution
+# =============================================================================
+
+# Auto-detect multi-PRD mode if prds/ directory exists
+if [ -d "$PRDS_DIR" ] && [ "$(ls -A "$PRDS_DIR"/*.json 2>/dev/null)" ]; then
+  MULTI_PRD_MODE=true
+  echo "Detected prds/ directory - enabling multi-PRD mode"
 fi
 
 # Initialize progress file if it doesn't exist
@@ -79,12 +230,107 @@ if [ ! -f "$PROGRESS_FILE" ]; then
   echo "---" >> "$PROGRESS_FILE"
 fi
 
-echo "Starting Ralph - Tool: $TOOL - Max iterations: $MAX_ITERATIONS"
+# Track current PRD source for multi-PRD mode
+CURRENT_PRD_SOURCE=""
 
-for i in $(seq 1 $MAX_ITERATIONS); do
+if [ "$MULTI_PRD_MODE" = true ]; then
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════════════╗"
+  echo "║           RALPH - Multi-PRD Mode                              ║"
+  echo "╠═══════════════════════════════════════════════════════════════╣"
+  echo "║  Tool: $TOOL"
+  echo "║  Max iterations per PRD: $MAX_ITERATIONS"
+  echo "║  PRDs directory: $PRDS_DIR"
+  echo "╚═══════════════════════════════════════════════════════════════╝"
+
+  # List all PRDs with their priorities
+  echo ""
+  echo "PRD Queue (by priority):"
+  echo "─────────────────────────────────────────────────────────────────"
+  for prd in "$PRDS_DIR"/*.json; do
+    [ -f "$prd" ] || continue
+    prd_name=$(basename "$prd")
+    priority=$(jq -r '.priority // 999' "$prd" 2>/dev/null || echo "?")
+    project=$(jq -r '.project // "?"' "$prd" 2>/dev/null || echo "?")
+    story_count=$(jq '.userStories | length' "$prd" 2>/dev/null || echo "?")
+    complete_count=$(jq '[.userStories[] | select(.passes == true)] | length' "$prd" 2>/dev/null || echo "0")
+
+    if grep -q "^${prd_name}$" "$COMPLETED_PRDS_FILE" 2>/dev/null; then
+      status="[DONE]"
+    elif is_prd_complete "$prd"; then
+      status="[DONE]"
+    else
+      status="[${complete_count}/${story_count}]"
+    fi
+
+    printf "  Priority %s: %-30s %s %s\n" "$priority" "$project" "$status" "$prd_name"
+  done | sort -t: -k1 -n
+  echo "─────────────────────────────────────────────────────────────────"
+
+  # Get next PRD
+  CURRENT_PRD_SOURCE=$(get_next_prd)
+
+  if [ -z "$CURRENT_PRD_SOURCE" ]; then
+    echo ""
+    echo "All PRDs are complete!"
+    exit 0
+  fi
+
+  activate_prd "$CURRENT_PRD_SOURCE"
+else
+  echo "Starting Ralph - Tool: $TOOL - Max iterations: $MAX_ITERATIONS"
+  archive_previous_run
+fi
+
+track_current_branch
+
+# Main iteration loop
+TOTAL_ITERATIONS=0
+PRD_ITERATIONS=0
+
+while true; do
+  ((TOTAL_ITERATIONS++))
+  ((PRD_ITERATIONS++))
+
+  # Check iteration limits
+  if [ $PRD_ITERATIONS -gt $MAX_ITERATIONS ]; then
+    if [ "$MULTI_PRD_MODE" = true ]; then
+      echo ""
+      echo "Max iterations ($MAX_ITERATIONS) reached for current PRD."
+
+      # Sync changes back to source PRD
+      sync_prd_changes "$CURRENT_PRD_SOURCE"
+
+      # Try to get next PRD
+      CURRENT_PRD_SOURCE=$(get_next_prd)
+
+      if [ -z "$CURRENT_PRD_SOURCE" ]; then
+        echo "All PRDs are complete!"
+        exit 0
+      fi
+
+      # Reset iteration counter for new PRD
+      PRD_ITERATIONS=1
+      activate_prd "$CURRENT_PRD_SOURCE"
+      track_current_branch
+    else
+      echo ""
+      echo "Ralph reached max iterations ($MAX_ITERATIONS) without completing all tasks."
+      echo "Check $PROGRESS_FILE for status."
+      exit 1
+    fi
+  fi
+
   echo ""
   echo "==============================================================="
-  echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL)"
+  if [ "$MULTI_PRD_MODE" = true ]; then
+    remaining=$(count_remaining_prds)
+    current_prd_name=$(basename "$CURRENT_PRD_SOURCE" 2>/dev/null || echo "prd.json")
+    echo "  Ralph Iteration $PRD_ITERATIONS/$MAX_ITERATIONS ($TOOL)"
+    echo "  PRD: $current_prd_name | Remaining PRDs: $remaining"
+  else
+    echo "  Ralph Iteration $PRD_ITERATIONS of $MAX_ITERATIONS ($TOOL)"
+  fi
   echo "==============================================================="
 
   # Run the selected tool with the ralph prompt
@@ -94,20 +340,64 @@ for i in $(seq 1 $MAX_ITERATIONS); do
     # Claude Code: use --dangerously-skip-permissions for autonomous operation, --print for output
     OUTPUT=$(claude --dangerously-skip-permissions --print < "$SCRIPT_DIR/CLAUDE.md" 2>&1 | tee /dev/stderr) || true
   fi
-  
+
+  # Sync changes back to source PRD in multi-PRD mode
+  if [ "$MULTI_PRD_MODE" = true ] && [ -n "$CURRENT_PRD_SOURCE" ]; then
+    sync_prd_changes "$CURRENT_PRD_SOURCE"
+  fi
+
   # Check for completion signal
   if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
-    echo ""
-    echo "Ralph completed all tasks!"
-    echo "Completed at iteration $i of $MAX_ITERATIONS"
-    exit 0
+    if [ "$MULTI_PRD_MODE" = true ]; then
+      current_prd_name=$(basename "$CURRENT_PRD_SOURCE" 2>/dev/null || echo "prd.json")
+      echo ""
+      echo "PRD completed: $current_prd_name"
+
+      # Mark this PRD as completed
+      echo "$current_prd_name" >> "$COMPLETED_PRDS_FILE"
+
+      # Archive the completed PRD
+      DATE=$(date +%Y-%m-%d)
+      BRANCH_NAME=$(jq -r '.branchName // "unknown"' "$PRD_FILE" 2>/dev/null || echo "unknown")
+      FOLDER_NAME=$(echo "$BRANCH_NAME" | sed 's|^ralph/||')
+      ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
+
+      mkdir -p "$ARCHIVE_FOLDER"
+      cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
+      [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
+      echo "   Archived to: $ARCHIVE_FOLDER"
+
+      # Reset progress file for next PRD
+      echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+      echo "Started: $(date)" >> "$PROGRESS_FILE"
+      echo "---" >> "$PROGRESS_FILE"
+
+      # Try to get next PRD
+      CURRENT_PRD_SOURCE=$(get_next_prd)
+
+      if [ -z "$CURRENT_PRD_SOURCE" ]; then
+        echo ""
+        echo "╔═══════════════════════════════════════════════════════════════╗"
+        echo "║           ALL PRDs COMPLETE!                                  ║"
+        echo "╠═══════════════════════════════════════════════════════════════╣"
+        echo "║  Total iterations: $TOTAL_ITERATIONS"
+        echo "╚═══════════════════════════════════════════════════════════════╝"
+        exit 0
+      fi
+
+      # Reset iteration counter for new PRD
+      PRD_ITERATIONS=0
+      activate_prd "$CURRENT_PRD_SOURCE"
+      track_current_branch
+    else
+      echo ""
+      echo "Ralph completed all tasks!"
+      echo "Completed at iteration $PRD_ITERATIONS of $MAX_ITERATIONS"
+      exit 0
+    fi
+  else
+    echo "Iteration $PRD_ITERATIONS complete. Continuing..."
   fi
-  
-  echo "Iteration $i complete. Continuing..."
+
   sleep 2
 done
-
-echo ""
-echo "Ralph reached max iterations ($MAX_ITERATIONS) without completing all tasks."
-echo "Check $PROGRESS_FILE for status."
-exit 1


### PR DESCRIPTION
## Summary

- Adds support for a `prds/` directory containing multiple PRD files
- Each PRD can have a `priority` field (lower number = higher priority)
- Ralph processes PRDs sequentially from highest to lowest priority
- After completing one PRD, automatically archives it and moves to the next
- Only exits when ALL PRDs are complete

## How It Works

1. Place PRD files in `prds/` directory with a `priority` field:
```json
{
  "project": "MyApp",
  "branchName": "ralph/feature-one",
  "priority": 1,
  "userStories": [...]
}
```

2. Ralph auto-detects the `prds/` directory and enables multi-PRD mode

3. At startup, shows PRD queue with progress:
```
PRD Queue (by priority):
─────────────────────────────────────────────────────────────────
  Priority 1: DatabaseSetup                [0/3] 01-database.json
  Priority 2: UserAuth                     [0/4] 02-auth.json
  Priority 3: TaskManagement               [0/5] 03-tasks.json
─────────────────────────────────────────────────────────────────
```

## Changes

- **ralph.sh**: Added multi-PRD helper functions and main loop logic
- **prd.json.example**: Added `priority` field
- **prds/*.json.example**: Added example PRD files for multi-PRD setup
- **.gitignore**: Added `.completed-prds` tracking file
- **README.md**: Documented multi-PRD mode

## Backward Compatibility

- Single `prd.json` mode still works exactly as before
- Multi-PRD mode only activates when `prds/` directory exists with `.json` files

## Test plan

- [ ] Test single PRD mode still works
- [ ] Test multi-PRD mode processes in priority order
- [ ] Test PRD archiving on completion
- [ ] Test continuation to next PRD after completion

🤖 Generated with [Claude Code](https://claude.ai/code)