### PR TITLE
fix: branch creation defaults to current HEAD instead of main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ You are an autonomous coding agent working on a software project.
 
 1. Read the PRD at `prd.json` (in the same directory as this file)
 2. Read the progress log at `progress.txt` (check Codebase Patterns section first)
-3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create from main.
+3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create it from `baseBranch` (if specified in PRD) or from the current HEAD.
 4. Pick the **highest priority** user story where `passes: false`
 5. Implement that single user story
 6. Run quality checks (e.g., typecheck, lint, test - use whatever your project requires)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This creates `prd.json` with user stories structured for autonomous execution.
 Default is 10 iterations. Use `--tool amp` or `--tool claude` to select your AI coding tool.
 
 Ralph will:
-1. Create a feature branch (from PRD `branchName`)
+1. Create a feature branch (from PRD `branchName`, based on `baseBranch` if specified, otherwise from current HEAD)
 2. Pick the highest priority story where `passes: false`
 3. Implement that single story
 4. Run quality checks (typecheck, tests)
@@ -114,7 +114,7 @@ Ralph will:
 | `ralph.sh` | The bash loop that spawns fresh AI instances (supports `--tool amp` or `--tool claude`) |
 | `prompt.md` | Prompt template for Amp |
 | `CLAUDE.md` | Prompt template for Claude Code |
-| `prd.json` | User stories with `passes` status (the task list) |
+| `prd.json` | User stories with `passes` status (the task list). Supports optional `baseBranch` field to specify which branch to create feature branches from (defaults to current HEAD) |
 | `prd.json.example` | Example PRD format for reference |
 | `progress.txt` | Append-only learnings for future iterations |
 | `skills/prd/` | Skill for generating PRDs |

--- a/prd.json.example
+++ b/prd.json.example
@@ -1,6 +1,7 @@
 {
   "project": "MyApp",
   "branchName": "ralph/task-priority",
+  "baseBranch": "develop",
   "description": "Task Priority System - Add priority levels to tasks",
   "userStories": [
     {

--- a/prompt.md
+++ b/prompt.md
@@ -6,7 +6,7 @@ You are an autonomous coding agent working on a software project.
 
 1. Read the PRD at `prd.json` (in the same directory as this file)
 2. Read the progress log at `progress.txt` (check Codebase Patterns section first)
-3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create from main.
+3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create it from `baseBranch` (if specified in PRD) or from the current HEAD.
 4. Pick the **highest priority** user story where `passes: false`
 5. Implement that single user story
 6. Run quality checks (e.g., typecheck, lint, test - use whatever your project requires)


### PR DESCRIPTION
## Summary

This PR fixes the branch creation behavior to use the current HEAD or an optional `baseBranch` instead of always defaulting to `main`.

## Problem

When the PRD's `branchName` doesn't exist, the agent instructions say to "create from main". This causes issues when using a development branch (e.g., `stage`) as the integration point, leading to:
- New work based on stale code
- Massive merge conflicts due to diverged architectures

## Solution

- Updated `prompt.md` and `CLAUDE.md` to create branches from `baseBranch` (if specified in PRD) or from the current HEAD
- Added optional `baseBranch` field to `prd.json.example`
- Updated `README.md` to document the new option

## Changes

- `prompt.md`: Updated step 3 to use `baseBranch` or current HEAD
- `CLAUDE.md`: Updated step 3 to use `baseBranch` or current HEAD  
- `prd.json.example`: Added `baseBranch` field example
- `README.md`: Documented the new `baseBranch` option

Fixes #40