### PR TITLE
fix: rewrite agent instructions from agent perspective

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Ralph is an autonomous AI agent loop that runs AI coding tools (Amp or Claude Code) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context.
+Ralph is an autonomous AI agent loop that runs AI coding tools (Amp or Claude Code) repeatedly until all PRD items are complete. Each session is a fresh instance with clean context—**sessions do not share memory with each other**.
 
 ## Commands
 
@@ -14,10 +14,10 @@ cd flowchart && npm run dev
 cd flowchart && npm run build
 
 # Run Ralph with Amp (default)
-./ralph.sh [max_iterations]
+./ralph.sh [max_sessions]
 
 # Run Ralph with Claude Code
-./ralph.sh --tool claude [max_iterations]
+./ralph.sh --tool claude [max_sessions]
 ```
 
 ## Key Files
@@ -41,7 +41,7 @@ npm run dev
 
 ## Patterns
 
-- Each iteration spawns a fresh AI instance (Amp or Claude Code) with clean context
-- Memory persists via git history, `progress.txt`, and `prd.json`
+- Each session spawns a fresh AI instance (Amp or Claude Code) with clean context
+- Sessions do NOT share memory—all persistent knowledge must be written to files (git history, `progress.txt`, `prd.json`, and `AGENTS.md`)
 - Stories should be small enough to complete in one context window
-- Always update AGENTS.md with discovered patterns for future iterations
+- Always update AGENTS.md with discovered patterns so future sessions can benefit (they cannot read your memory, only files)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 You are an autonomous coding agent working on a software project.
 
+**Important:** Each session starts fresh with no memory of previous sessions. Your only knowledge comes from reading files. This is why documenting learnings in `progress.txt` and `CLAUDE.md` is critical—future sessions will rely on what you write.
+
 ## Your Task
 
 1. Read the PRD at `prd.json` (in the same directory as this file)
@@ -22,18 +24,18 @@ APPEND to progress.txt (never replace, always append):
 ## [Date/Time] - [Story ID]
 - What was implemented
 - Files changed
-- **Learnings for future iterations:**
+- **Learnings for future sessions:**
   - Patterns discovered (e.g., "this codebase uses X for Y")
   - Gotchas encountered (e.g., "don't forget to update Z when changing W")
   - Useful context (e.g., "the evaluation panel is in component X")
 ---
 ```
 
-The learnings section is critical - it helps future iterations avoid repeating mistakes and understand the codebase better.
+The learnings section is critical—future sessions have no memory of your work except what you write to files. Document anything that would help them avoid mistakes or understand the codebase better.
 
 ## Consolidate Patterns
 
-If you discover a **reusable pattern** that future iterations should know, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist). This section should consolidate the most important learnings:
+If you discover a **reusable pattern**, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist). This section should consolidate the most important learnings:
 
 ```
 ## Codebase Patterns
@@ -87,18 +89,25 @@ For any story that changes UI, verify it works in the browser if you have browse
 
 If no browser tools are available, note in your progress report that manual browser verification is needed.
 
+## Completion Criteria
+
+A story is **complete** when you have:
+- Implemented the code (step 5)
+- Passed all quality checks (step 6)
+- Committed with proper message format (step 8)
+- Set `passes: true` in prd.json (step 9)
+- Appended progress to progress.txt (step 10)
+
 ## Stop Condition
 
-After completing a user story, check if ALL stories have `passes: true`.
+After completing steps 1-10 for a user story, check if ALL stories have `passes: true`.
 
-If ALL stories are complete and passing, reply with:
-<promise>COMPLETE</promise>
-
-If there are still stories with `passes: false`, end your response normally (another iteration will pick up the next story).
+- **If ALL stories are complete:** Reply with `<promise>COMPLETE</promise>` and stop.
+- **If stories remain with `passes: false`:** End your session after completing steps 1-10. Your work is done for this session.
 
 ## Important
 
-- Work on ONE story per iteration
+- Work on ONE story per session
 - Commit frequently
 - Keep CI green
-- Read the Codebase Patterns section in progress.txt before starting
+- Read the Codebase Patterns section in progress.txt before starting—it contains knowledge from previous sessions

--- a/prompt.md
+++ b/prompt.md
@@ -2,6 +2,8 @@
 
 You are an autonomous coding agent working on a software project.
 
+**Important:** Each session starts fresh with no memory of previous sessions. Your only knowledge comes from reading files. This is why documenting learnings in `progress.txt` and `AGENTS.md` is critical—future sessions will rely on what you write.
+
 ## Your Task
 
 1. Read the PRD at `prd.json` (in the same directory as this file)
@@ -23,20 +25,20 @@ APPEND to progress.txt (never replace, always append):
 Thread: https://ampcode.com/threads/$AMP_CURRENT_THREAD_ID
 - What was implemented
 - Files changed
-- **Learnings for future iterations:**
+- **Learnings for future sessions:**
   - Patterns discovered (e.g., "this codebase uses X for Y")
   - Gotchas encountered (e.g., "don't forget to update Z when changing W")
   - Useful context (e.g., "the evaluation panel is in component X")
 ---
 ```
 
-Include the thread URL so future iterations can use the `read_thread` tool to reference previous work if needed.
+Include the thread URL so future sessions can use the `read_thread` tool to reference previous work if needed.
 
-The learnings section is critical - it helps future iterations avoid repeating mistakes and understand the codebase better.
+The learnings section is critical—future sessions have no memory of your work except what you write to files. Document anything that would help them avoid mistakes or understand the codebase better.
 
 ## Consolidate Patterns
 
-If you discover a **reusable pattern** that future iterations should know, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist). This section should consolidate the most important learnings:
+If you discover a **reusable pattern**, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist). This section should consolidate the most important learnings:
 
 ```
 ## Codebase Patterns
@@ -91,18 +93,25 @@ For any story that changes UI, you MUST verify it works in the browser:
 
 A frontend story is NOT complete until browser verification passes.
 
+## Completion Criteria
+
+A story is **complete** when you have:
+- Implemented the code (step 5)
+- Passed all quality checks (step 6)
+- Committed with proper message format (step 8)
+- Set `passes: true` in prd.json (step 9)
+- Appended progress to progress.txt (step 10)
+
 ## Stop Condition
 
-After completing a user story, check if ALL stories have `passes: true`.
+After completing steps 1-10 for a user story, check if ALL stories have `passes: true`.
 
-If ALL stories are complete and passing, reply with:
-<promise>COMPLETE</promise>
-
-If there are still stories with `passes: false`, end your response normally (another iteration will pick up the next story).
+- **If ALL stories are complete:** Reply with `<promise>COMPLETE</promise>` and stop.
+- **If stories remain with `passes: false`:** End your session after completing steps 1-10. Your work is done for this session.
 
 ## Important
 
-- Work on ONE story per iteration
+- Work on ONE story per session
 - Commit frequently
 - Keep CI green
-- Read the Codebase Patterns section in progress.txt before starting
+- Read the Codebase Patterns section in progress.txt before starting—it contains knowledge from previous sessions


### PR DESCRIPTION
## Summary
Fixes #47

Agent instructions contained abstraction leaks—they were written from the orchestrator's perspective, assuming the agent understands the Ralph loop. But each agent session starts fresh with no memory of previous invocations.

## Changes

### 1. Terminology: `iteration` → `session`
The word "iteration" implies knowledge of an outer loop. Changed to "session" which makes sense from the agent's POV.

### 2. Explicit Memory Statement
Added at the top of CLAUDE.md and prompt.md:
> **Important:** Each session starts fresh with no memory of previous sessions. Your only knowledge comes from reading files.

### 3. Completion Criteria Section
Added explicit criteria referencing specific step numbers (5, 6, 8, 9, 10) so the agent knows exactly when its work is done.

### 4. Improved Stop Condition
Before (vague):
> "end your response normally (another iteration will pick up the next story)"

After (explicit):
> "End your session after completing steps 1-10. Your work is done for this session."

### 5. Contextualized File Writing
Explained *why* writing to files matters—future sessions have no memory, only files.

## Files Modified
- `AGENTS.md` (12 lines)
- `CLAUDE.md` (29 lines)
- `prompt.md` (31 lines)

## Testing
The agent no longer needs to understand orchestration concepts—it only needs to follow the numbered steps and check the explicit completion criteria.