### PR TITLE
fix: make browser testing mandatory for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,15 +77,17 @@ Only update CLAUDE.md if you have **genuinely reusable knowledge** that would he
 - Keep changes focused and minimal
 - Follow existing code patterns
 
-## Browser Testing (If Available)
+## Browser Testing (Required for Frontend Stories)
 
-For any story that changes UI, verify it works in the browser if you have browser testing tools configured (e.g., via MCP):
+For any story that changes UI, you MUST verify it works in the browser:
 
-1. Navigate to the relevant page
-2. Verify the UI changes work as expected
-3. Take a screenshot if helpful for the progress log
+1. Load the `dev-browser` skill
+2. Navigate to the relevant page
+3. Verify the UI changes work as expected
+4. Also verify that ALL other pages/routes still work (no 404s, no broken navigation)
+5. Take a screenshot if helpful for the progress log
 
-If no browser tools are available, note in your progress report that manual browser verification is needed.
+A frontend story is NOT complete until browser verification passes.
 
 ## Stop Condition
 

--- a/prompt.md
+++ b/prompt.md
@@ -87,7 +87,8 @@ For any story that changes UI, you MUST verify it works in the browser:
 1. Load the `dev-browser` skill
 2. Navigate to the relevant page
 3. Verify the UI changes work as expected
-4. Take a screenshot if helpful for the progress log
+4. Also verify that ALL other pages/routes still work (no 404s, no broken navigation)
+5. Take a screenshot if helpful for the progress log
 
 A frontend story is NOT complete until browser verification passes.
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md** had weak "if available" browser testing language while **prompt.md** (Amp) had mandatory language with `dev-browser` skill
- This mismatch meant Claude Code iterations would skip browser verification entirely, logging "manual verification needed" instead of actually testing
- Added step to both files requiring verification of ALL pages/routes (not just the changed page) to catch 404s and broken navigation

## What changed
| File | Before | After |
|------|--------|-------|
| `CLAUDE.md` | "If Available" — optional, fallback to manual note | "Required for Frontend Stories" — mandatory, uses `dev-browser` skill |
| `prompt.md` | Verified only the changed page | Also verifies ALL other pages/routes still work |

## Why this matters
The README already states browser verification is required, but CLAUDE.md contradicted it. Claude takes the path of least resistance — if the prompt says "if available... note manual verification needed", it will always skip browser testing. This led to regressions like broken routes/404s going undetected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)