### PR TITLE
fix(skill): enforce options indentation in prd SKILL.md

### DIFF
--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -52,7 +52,7 @@ Ask only critical questions where the initial prompt is ambiguous. Focus on:
    D. Just the UI
 ```
 
-This lets users respond with "1A, 2C, 3B" for quick iteration.
+This lets users respond with "1A, 2C, 3B" for quick iteration. Remember to indent the options.
 
 ---
 


### PR DESCRIPTION
Added reminder to indent options for user responses. Some models (e.g. GLM 4.7) do not indent the options properly. This make hard for the user to read the questions/options.