### PR TITLE
Added cursor support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Ralph is an autonomous AI agent loop that runs AI coding tools (Amp or Claude Code) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context.
+Ralph is an autonomous AI agent loop that runs AI coding tools (Amp, Claude Code, or Cursor CLI) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context.
 
 ## Commands
 
@@ -18,13 +18,19 @@ cd flowchart && npm run build
 
 # Run Ralph with Claude Code
 ./ralph.sh --tool claude [max_iterations]
+
+# Run Ralph with Cursor CLI
+./ralph.sh --tool cursor [max_iterations]
+
+# Run Ralph with Cursor CLI and a specific model
+./ralph.sh --tool cursor [max_iterations] --model auto
 ```
 
 ## Key Files
 
-- `ralph.sh` - The bash loop that spawns fresh AI instances (supports `--tool amp` or `--tool claude`)
+- `ralph.sh` - The bash loop that spawns fresh AI instances (supports `--tool amp`, `--tool claude`, or `--tool cursor`)
 - `prompt.md` - Instructions given to each AMP instance
--  `CLAUDE.md` - Instructions given to each Claude Code instance
+- `CLAUDE.md` - Instructions given to each Claude Code or Cursor instance
 - `prd.json.example` - Example PRD format
 - `flowchart/` - Interactive React Flow diagram explaining how Ralph works
 
@@ -41,7 +47,7 @@ npm run dev
 
 ## Patterns
 
-- Each iteration spawns a fresh AI instance (Amp or Claude Code) with clean context
+- Each iteration spawns a fresh AI instance (Amp, Claude Code, or Cursor CLI) with clean context
 - Memory persists via git history, `progress.txt`, and `prd.json`
 - Stories should be small enough to complete in one context window
 - Always update AGENTS.md with discovered patterns for future iterations

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Ralph](ralph.webp)
 
-Ralph is an autonomous AI agent loop that runs AI coding tools ([Amp](https://ampcode.com) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code)) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context. Memory persists via git history, `progress.txt`, and `prd.json`.
+Ralph is an autonomous AI agent loop that runs AI coding tools ([Amp](https://ampcode.com), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or [Cursor CLI](https://cursor.com/docs/cli/headless)) repeatedly until all PRD items are complete. Each iteration is a fresh instance with clean context. Memory persists via git history, `progress.txt`, and `prd.json`.
 
 Based on [Geoffrey Huntley's Ralph pattern](https://ghuntley.com/ralph/).
 
@@ -13,6 +13,7 @@ Based on [Geoffrey Huntley's Ralph pattern](https://ghuntley.com/ralph/).
 - One of the following AI coding tools installed and authenticated:
   - [Amp CLI](https://ampcode.com) (default)
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
+  - [Cursor CLI](https://cursor.com/docs/cli/headless) (install via Cursor IDE or `curl https://cursor.com/install -fsS | bash`; use `cursor auth login` or `CURSOR_API_KEY` for headless)
 - `jq` installed (`brew install jq` on macOS)
 - A git repository for your project
 
@@ -30,14 +31,14 @@ cp /path/to/ralph/ralph.sh scripts/ralph/
 # Copy the prompt template for your AI tool of choice:
 cp /path/to/ralph/prompt.md scripts/ralph/prompt.md    # For Amp
 # OR
-cp /path/to/ralph/CLAUDE.md scripts/ralph/CLAUDE.md    # For Claude Code
+cp /path/to/ralph/CLAUDE.md scripts/ralph/CLAUDE.md    # For Claude Code or Cursor
 
 chmod +x scripts/ralph/ralph.sh
 ```
 
-### Option 2: Install skills globally (Amp)
+### Option 2: Install skills globally (Amp, Claude Code, Cursor)
 
-Copy the skills to your Amp or Claude config for use across all projects:
+Copy the skills to your Amp, Claude, or Cursor config for use across all projects:
 
 For AMP
 ```bash
@@ -49,6 +50,12 @@ For Claude Code (manual)
 ```bash
 cp -r skills/prd ~/.claude/skills/
 cp -r skills/ralph ~/.claude/skills/
+```
+
+For Cursor
+```bash
+cp -r skills/prd ~/.cursor/skills/
+cp -r skills/ralph ~/.cursor/skills/
 ```
 
 ### Option 3: Use as Claude Code Marketplace
@@ -115,9 +122,15 @@ This creates `prd.json` with user stories structured for autonomous execution.
 
 # Using Claude Code
 ./scripts/ralph/ralph.sh --tool claude [max_iterations]
+
+# Using Cursor CLI
+./scripts/ralph/ralph.sh --tool cursor [max_iterations]
+
+# Using Cursor CLI with a specific model (e.g. auto, claude-sonnet-4)
+./scripts/ralph/ralph.sh --tool cursor [max_iterations] --model auto
 ```
 
-Default is 10 iterations. Use `--tool amp` or `--tool claude` to select your AI coding tool.
+Default is 10 iterations. Use `--tool amp`, `--tool claude`, or `--tool cursor` to select your AI coding tool. With Cursor, use `--model MODEL` to pass a model name to the Cursor CLI (e.g. `--model auto`).
 
 Ralph will:
 1. Create a feature branch (from PRD `branchName`)
@@ -133,9 +146,9 @@ Ralph will:
 
 | File | Purpose |
 |------|---------|
-| `ralph.sh` | The bash loop that spawns fresh AI instances (supports `--tool amp` or `--tool claude`) |
+| `ralph.sh` | The bash loop that spawns fresh AI instances (supports `--tool amp`, `--tool claude`, or `--tool cursor`; Cursor supports `--model MODEL`) |
 | `prompt.md` | Prompt template for Amp |
-| `CLAUDE.md` | Prompt template for Claude Code |
+| `CLAUDE.md` | Prompt template for Claude Code and Cursor |
 | `prd.json` | User stories with `passes` status (the task list) |
 | `prd.json.example` | Example PRD format for reference |
 | `progress.txt` | Append-only learnings for future iterations |
@@ -223,7 +236,7 @@ git log --oneline -10
 
 ## Customizing the Prompt
 
-After copying `prompt.md` (for Amp) or `CLAUDE.md` (for Claude Code) to your project, customize it for your project:
+After copying `prompt.md` (for Amp) or `CLAUDE.md` (for Claude Code or Cursor) to your project, customize it for your project:
 - Add project-specific quality check commands
 - Include codebase conventions
 - Add common gotchas for your stack
@@ -237,3 +250,4 @@ Ralph automatically archives previous runs when you start a new feature (differe
 - [Geoffrey Huntley's Ralph article](https://ghuntley.com/ralph/)
 - [Amp documentation](https://ampcode.com/manual)
 - [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Cursor CLI documentation](https://cursor.com/docs/cli/headless)

--- a/ralph.sh
+++ b/ralph.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # Ralph Wiggum - Long-running AI agent loop
-# Usage: ./ralph.sh [--tool amp|claude] [max_iterations]
+# Usage: ./ralph.sh [--tool amp|claude|cursor] [--model MODEL] [max_iterations]
 
 set -e
 
 # Parse arguments
 TOOL="amp"  # Default to amp for backwards compatibility
 MAX_ITERATIONS=10
+MODEL=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -16,6 +17,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tool=*)
       TOOL="${1#*=}"
+      shift
+      ;;
+    --model)
+      MODEL="$2"
+      shift 2
+      ;;
+    --model=*)
+      MODEL="${1#*=}"
       shift
       ;;
     *)
@@ -29,8 +38,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate tool choice
-if [[ "$TOOL" != "amp" && "$TOOL" != "claude" ]]; then
-  echo "Error: Invalid tool '$TOOL'. Must be 'amp' or 'claude'."
+if [[ "$TOOL" != "amp" && "$TOOL" != "claude" && "$TOOL" != "cursor" ]]; then
+  echo "Error: Invalid tool '$TOOL'. Must be 'amp', 'claude', or 'cursor'."
   exit 1
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -80,19 +89,30 @@ if [ ! -f "$PROGRESS_FILE" ]; then
 fi
 
 echo "Starting Ralph - Tool: $TOOL - Max iterations: $MAX_ITERATIONS"
+[[ -n "$MODEL" ]] && echo "Model: $MODEL"
 
 for i in $(seq 1 $MAX_ITERATIONS); do
   echo ""
   echo "==============================================================="
-  echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL)"
+  if [[ -n "$MODEL" ]]; then
+    echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL) - Model: $MODEL"
+  else
+    echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL)"
+  fi
   echo "==============================================================="
 
   # Run the selected tool with the ralph prompt
   if [[ "$TOOL" == "amp" ]]; then
     OUTPUT=$(cat "$SCRIPT_DIR/prompt.md" | amp --dangerously-allow-all 2>&1 | tee /dev/stderr) || true
-  else
+  elif [[ "$TOOL" == "claude" ]]; then
     # Claude Code: use --dangerously-skip-permissions for autonomous operation, --print for output
     OUTPUT=$(claude --dangerously-skip-permissions --print < "$SCRIPT_DIR/CLAUDE.md" 2>&1 | tee /dev/stderr) || true
+  else
+    # Cursor CLI: --print for non-interactive output, --force to allow file/shell changes without confirmation
+    CURSOR_PROMPT="Run one Ralph iteration. Follow the instructions in CLAUDE.md in this workspace. Do one user story from prd.json, then stop. If all user stories have passes true, reply with exactly <promise>COMPLETE</promise>. Otherwise do not include that tag."
+    CURSOR_CMD=(agent -p -f)
+    [[ -n "$MODEL" ]] && CURSOR_CMD+=(--model "$MODEL")
+    OUTPUT=$(cd "$SCRIPT_DIR" && "${CURSOR_CMD[@]}" "$CURSOR_PROMPT" 2>&1 | tee /dev/stderr) || true
   fi
   
   # Check for completion signal


### PR DESCRIPTION
**Add Cursor CLI support**
Ralph can now use Cursor CLI as a backend (in addition to Amp and Claude Code) for the autonomous agent loop.

**Changes**
ralph.sh: New --tool cursor and optional --model MODEL. Invokes Cursor CLI with a single-iteration prompt and agent -p -f for non-interactive, autonomous runs.
README.md: Cursor install/setup, --tool cursor / --model usage, Cursor skills path (~/.cursor/skills/), and link to Cursor CLI docs.
AGENTS.md: Cursor added to overview, commands, key files, and patterns.

**Usage**
```
./ralph.sh --tool cursor [max_iterations]
./ralph.sh --tool cursor [max_iterations] --model auto
```
Requires Cursor CLI installed and authenticated (cursor auth login or CURSOR_API_KEY for headless). Uses the same CLAUDE.md prompt as Claude Code.