### PR TITLE
Add flick: Ralph cleanup skill and script

### DIFF
--- a/flick.sh
+++ b/flick.sh
@@ -3,13 +3,14 @@
 # Finds and deletes Ralph intermediary files (prd.json, progress.txt).
 # Run this from your project directory after a successful Ralph run.
 #
-# Usage: bash /path/to/ralph/flick.sh [--nuke]
+# Usage: bash /path/to/ralph/flick.sh [--nuke|--all]
 #   --nuke  Skip confirmation prompts and delete all files immediately
+#   --all   Alias for --nuke
 
 nuke=false
 project_dir="${PWD}"
 
-[[ "$1" == "--nuke" ]] && nuke=true
+[[ "$1" == "--nuke" || "$1" == "--all" ]] && nuke=true
 
 search_dirs=(
   "${project_dir}"

--- a/flick.sh
+++ b/flick.sh
@@ -14,6 +14,7 @@ project_dir="${PWD}"
 
 search_dirs=(
   "${project_dir}"
+  "${project_dir}/tasks"
   "${project_dir}/ralph"
   "${project_dir}/.agents/ralph"
   "${project_dir}/.claude/ralph"

--- a/flick.sh
+++ b/flick.sh
@@ -17,9 +17,13 @@ search_dirs=(
   "${project_dir}/tasks"
   "${project_dir}/ralph"
   "${project_dir}/.agents/ralph"
+  "${project_dir}/.agents/skills/ralph"
   "${project_dir}/.claude/ralph"
+  "${project_dir}/.claude/skills/ralph"
   "${HOME}/.agents/ralph"
+  "${HOME}/.agents/skills/ralph"
   "${HOME}/.claude/ralph"
+  "${HOME}/.claude/skills/ralph"
 )
 
 found_any=false

--- a/flick.sh
+++ b/flick.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# flick.sh — Ralph cleanup utility
+# Finds and deletes Ralph intermediary files (prd.json, progress.txt).
+# Run this from your project directory after a successful Ralph run.
+#
+# Usage: bash /path/to/ralph/flick.sh [--nuke]
+#   --nuke  Skip confirmation prompts and delete all files immediately
+
+nuke=false
+project_dir="${PWD}"
+
+[[ "$1" == "--nuke" ]] && nuke=true
+
+search_dirs=(
+  "${project_dir}"
+  "${project_dir}/ralph"
+  "${project_dir}/.agents/ralph"
+  "${project_dir}/.claude/ralph"
+  "${HOME}/.agents/ralph"
+  "${HOME}/.claude/ralph"
+)
+
+found_any=false
+
+for dir in "${search_dirs[@]}"; do
+  dir_files=()
+  for fname in prd.json progress.txt; do
+    [[ -f "${dir}/${fname}" ]] && dir_files+=("${dir}/${fname}")
+  done
+
+  [[ ${#dir_files[@]} -eq 0 ]] && continue
+  found_any=true
+
+  echo ""
+  echo "════════════════════════════════════════"
+  echo "Location: ${dir}"
+
+  filenames=()
+  for f in "${dir_files[@]}"; do
+    filenames+=("$(basename "$f")")
+  done
+  echo "Files:    $(IFS=', '; echo "${filenames[*]}")"
+
+  prd="${dir}/prd.json"
+  if [[ -f "$prd" ]]; then
+    echo ""
+    echo "── prd.json (first 15 lines) ──────────"
+    head -15 "$prd"
+  fi
+
+  echo ""
+
+  if $nuke; then
+    for f in "${dir_files[@]}"; do
+      rm "$f" && echo "  Deleted: $f"
+    done
+  else
+    read -p "Delete these files? (y/n) " reply
+    echo ""
+    if [[ "$reply" =~ ^[Yy]$ ]]; then
+      for f in "${dir_files[@]}"; do
+        rm "$f" && echo "  Deleted: $f"
+      done
+    else
+      echo "  Skipped."
+    fi
+  fi
+done
+
+if ! $found_any; then
+  echo "No Ralph files found in any expected location."
+else
+  echo ""
+  echo "════════════════════════════════════════"
+  echo "Done."
+fi

--- a/ralph.sh
+++ b/ralph.sh
@@ -100,6 +100,10 @@ for i in $(seq 1 $MAX_ITERATIONS); do
     echo ""
     echo "Ralph completed all tasks!"
     echo "Completed at iteration $i of $MAX_ITERATIONS"
+    echo ""
+    echo "Tip: clean up Ralph's intermediary files when you're ready:"
+    echo "  Via your AI coding tool : /flick"
+    echo "  Via script (from project): path/to/ralph/flick.sh"
     exit 0
   fi
   

--- a/skills/flick/SKILL.md
+++ b/skills/flick/SKILL.md
@@ -18,9 +18,13 @@ Search for Ralph intermediary files in the following locations (relative to the 
 2. `{project_root}/tasks/`
 3. `{project_root}/ralph/`
 4. `{project_root}/.agents/ralph/`
-5. `{project_root}/.claude/ralph/`
-6. `~/.agents/ralph/`
-7. `~/.claude/ralph/`
+5. `{project_root}/.agents/skills/ralph/`
+6. `{project_root}/.claude/ralph/`
+7. `{project_root}/.claude/skills/ralph/`
+8. `~/.agents/ralph/`
+9. `~/.agents/skills/ralph/`
+10. `~/.claude/ralph/`
+11. `~/.claude/skills/ralph/`
 
 Where `{project_root}` is the root of the current project (the working directory).
 

--- a/skills/flick/SKILL.md
+++ b/skills/flick/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: flick
+description: "Clean up Ralph intermediary files (prd.json, progress.txt) after a completed run. Triggers on: flick, flick booger, clean up ralph files, remove prd.json, delete progress.txt, ralph cleanup."
+user-invocable: true
+---
+
+# Flick — Ralph Cleanup
+
+Finds and removes `prd.json` and `progress.txt` left behind by a Ralph run.
+
+---
+
+## The Job
+
+Search for Ralph intermediary files in the following locations (relative to the current project directory, and at the user level):
+
+1. `{project_root}/`
+2. `{project_root}/ralph/`
+3. `{project_root}/.agents/ralph/`
+4. `{project_root}/.claude/ralph/`
+5. `~/.agents/ralph/`
+6. `~/.claude/ralph/`
+
+Where `{project_root}` is the root of the current project (the working directory).
+
+---
+
+## Steps
+
+1. **Find all instances** of `prd.json` and `progress.txt` across every location above.
+
+2. **If nothing is found**, tell the user: no Ralph files found.
+
+3. **For each location that has files:**
+   - Show the location path and which files were found there
+   - If a `prd.json` exists at that location, show its first 15 lines
+   - Ask the user: "Delete these files? (y/n)"
+   - If yes, delete them and confirm each deletion
+   - If no, skip and move to the next location
+
+4. **When all locations are processed**, give a brief summary of what was deleted vs skipped.
+
+---
+
+## Notes
+
+- Be precise about paths when reporting — show the full path of each file found and deleted.
+- Do not delete any files without confirmation.
+- If the user passes `--nuke`, `--all`, or says "nuke it" / "delete everything" / "delete all", skip the per-location prompts and delete all found files immediately.

--- a/skills/flick/SKILL.md
+++ b/skills/flick/SKILL.md
@@ -15,11 +15,12 @@ Finds and removes `prd.json` and `progress.txt` left behind by a Ralph run.
 Search for Ralph intermediary files in the following locations (relative to the current project directory, and at the user level):
 
 1. `{project_root}/`
-2. `{project_root}/ralph/`
-3. `{project_root}/.agents/ralph/`
-4. `{project_root}/.claude/ralph/`
-5. `~/.agents/ralph/`
-6. `~/.claude/ralph/`
+2. `{project_root}/tasks/`
+3. `{project_root}/ralph/`
+4. `{project_root}/.agents/ralph/`
+5. `{project_root}/.claude/ralph/`
+6. `~/.agents/ralph/`
+7. `~/.claude/ralph/`
 
 Where `{project_root}` is the root of the current project (the working directory).
 


### PR DESCRIPTION
## Motivation
Found myself needing to search for and cleanup these files (admittedly I just wanted to not archive, and just blow these intermediary files away), so I made this little helper.

Thought it might be useful for others, so sharing.

## Summary
- Adds a `/flick` skill and `flick.sh` script to find and delete Ralph intermediary files (`prd.json`, `progress.txt`) after a completed run.
- Updates `ralph.sh` to display a cleanup tip on successful completion.

### Screenshot
#### skill-based
<img width="593" height="774" alt="image" src="https://github.com/user-attachments/assets/322cf899-c039-4c38-bf3b-51c3bdb46a0b" />

#### script-based
```bash
❯ ./ralph.sh --tool claude
Starting Ralph - Tool: claude - Max iterations: 10

===============================================================
  Ralph Iteration 1 of 10 (claude)
===============================================================
All stories have `passes: true`.

<promise>COMPLETE</promise>

Ralph completed all tasks!
Completed at iteration 1 of 10

Tip: clean up Ralph's intermediary files when you're ready:
  Via your AI coding tool : /flick
  Via script (from project): path/to/ralph/flick.sh
  
  ❯ ./flick.sh

════════════════════════════════════════
Location: /Users/josh/src/ralph
Files:    prd.json,progress.txt

── prd.json (first 15 lines) ──────────
{
  "project": "Ralph",
  "branchName": "ralph/readme-benign-change",
  "description": "README Benign Change - Add one line to README.md to verify the Ralph pipeline end-to-end",
  "userStories": [
    {
      "id": "US-001",
      "title": "Add a note to README.md",
      "description": "As a developer, I want to add one benign line to README.md so that the Ralph pipeline is verified end-to-end.",
      "acceptanceCriteria": [
        "One line added to README.md (e.g., a badge, a note, or a minor clarification)",
        "Change is accurate and not misleading",
        "No other files modified besides README.md",
        "Commit is clean and repo remains in a healthy state"
      ],

Delete these files? (y/n)
```

## Key Changes
### skills/flick/SKILL.md — Claude Code skill
- Defines the `/flick` skill so users can trigger cleanup directly from their AI coding tool
- Supports `--nuke`, `--all`, "nuke it", "delete everything", and "delete all" as force-delete triggers
- Covers the same search locations as the shell script

### flick.sh — cleanup script
- Alternative to ai-native skill (more direct, less token usage, if developer prefers)
- Searches known Ralph file locations (project root, `.agents/ralph`, `.claude/ralph`, and user-level equivalents)
- Shows a preview of `prd.json` (first 15 lines) before prompting for deletion
- Supports `--nuke` and `--all` flags to skip confirmation prompts and delete all found files immediately

### ralph.sh — completion tip
- Prints a helpful tip on successful run completion pointing users to both the `/flick` skill and `flick.sh` script